### PR TITLE
Fix comment API endpoints to use server client

### DIFF
--- a/pages/api/comments/index.ts
+++ b/pages/api/comments/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { supabaseBrowser } from "@/lib/supabase/browser";
+import { supabaseApi } from "@/lib/supabase/api";
 
 export default async function handler(
   req: NextApiRequest,
@@ -14,7 +14,16 @@ export default async function handler(
     return res.status(400).json({ error: "Missing applicant_id" });
   }
 
-  const supabase = supabaseBrowser();
+  const supabase = supabaseApi(req, res);
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
 
   const { data, error } = await supabase
     .from("applicant_rounds")

--- a/pages/api/comments/indexall.ts
+++ b/pages/api/comments/indexall.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { supabaseBrowser } from "@/lib/supabase/browser";
+import { supabaseApi } from "@/lib/supabase/api";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   // Only allow POST
@@ -15,7 +15,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: "Missing required field: applicant_id" });
   }
 
-  const supabase = supabaseBrowser();
+  const supabase = supabaseApi(req, res);
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
 
   /*
     We'll select from "comments" and nest relationships:


### PR DESCRIPTION
## Summary
- use `supabaseApi` on comment endpoints
- verify authenticated user on comment APIs

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846352cd1d883308c06d1426a3a6233