### PR TITLE
Add Supabase health check and refresh dependencies

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+
+import { supabaseServer } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+async function checkDatabase() {
+  const supabase = await supabaseServer();
+  const { error } = await supabase
+    .from("recruitment_cycles")
+    .select("id")
+    .limit(1);
+
+  return error;
+}
+
+export async function GET() {
+  try {
+    const error = await checkDatabase();
+
+    if (error) {
+      console.error("Database health check failed", {
+        code: error.code,
+        message: error.message,
+      });
+
+      return NextResponse.json(
+        { status: "unhealthy", database: "unreachable" },
+        {
+          status: 503,
+          headers: { "Cache-Control": "no-store" },
+        },
+      );
+    }
+
+    return NextResponse.json(
+      { status: "ok", database: "reachable" },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    console.error("Database health check threw", error);
+
+    return NextResponse.json(
+      { status: "unhealthy", database: "unreachable" },
+      {
+        status: 503,
+        headers: { "Cache-Control": "no-store" },
+      },
+    );
+  }
+}
+
+export const HEAD = GET;


### PR DESCRIPTION
## What changed

- Adds a dynamic `GET`/`HEAD` endpoint at `/api/health` that performs a minimal read-only query against Supabase
- Refreshes the lockfile within the existing semver ranges, including patched Next.js, PostCSS, DOMPurify, Supabase, WebSocket, and Supabase CLI transitive dependencies
- Removes unused direct dependencies `react-router-dom` and `react-email`
- Pins development and deployment to Node.js 24 through `package.json` and `.nvmrc`

## Why

The health endpoint provides a database-backed UptimeRobot target. The dependency refresh resolves the existing npm audit findings, including the critical `tar` advisory inherited through the Supabase CLI.

## Validation

- Clean install completed under Node.js 24.19.0
- `npm audit`: 0 vulnerabilities (previously 94: 2 low, 70 moderate, 21 high, 1 critical)
- `npm run build`: passed under Node.js 24.19.0 with Next.js 16.3.0
- Health route ESLint: passed using Next.js core-web-vitals rules
- Direct read-only query against the live Supabase project returned HTTP 200

## Known pre-existing issue

The repository's `npm run lint` script still invokes the removed `next lint` command. Running the current Next.js ESLint rules across the full repository surfaces 31 existing errors and 3 warnings, primarily React effect patterns; those are outside this focused dependency and health-check change.